### PR TITLE
Template Context and Filtering PR

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -31,3 +31,5 @@ tests/
 build/
 .goxc.local.json
 .DS_Store
+samples/*
+.vscode

--- a/commands/marathon/app_cmds.go
+++ b/commands/marathon/app_cmds.go
@@ -52,10 +52,14 @@ var appUpdateMemoryCmd = &cobra.Command{
 }
 
 var appListCmd = &cobra.Command{
-	Use:   "list",
+	Use:   "list (optional filtering - label=mylabel | id=/services | cmd=java ...)",
 	Short: "List all applications",
 	Run: func(cmd *cobra.Command, args []string) {
-		v, e := client(cmd).ListApplications()
+		filter := ""
+		if len(args) > 0 {
+			filter = args[0]
+		}
+		v, e := client(cmd).ListApplicationsWithFilters(filter)
 
 		cli.Output(templateFor(templateFormat(T_APPLICATIONS, cmd), v), e)
 	},

--- a/commands/marathon/deploy_cmds.go
+++ b/commands/marathon/deploy_cmds.go
@@ -29,11 +29,59 @@ var deployDeleteCmd = &cobra.Command{
 		if cli.EvalPrintUsage(cmd.Usage, args, 1) {
 			return
 		}
-		v, e := client(cmd).DeleteDeployment(args[0])
+		force, _ := cmd.Flags().GetBool(FORCE_FLAG)
+
+		v, e := client(cmd).DeleteDeployment(args[0], force)
 		cli.Output(templateFor(T_DEPLOYMENT_ID, v), e)
 	},
 }
 
+var deleteIfDeployingCmd = &cobra.Command{
+	Use:   "cancel-app [appid]",
+	Short: "Conditional Match: Delete a deployment based on the specified [appid]",
+	Run: func(cmd *cobra.Command, args []string) {
+		if cli.EvalPrintUsage(cmd.Usage, args, 1) {
+			return
+		}
+		v, e := client(cmd).CancelAppDeployment(args[0], false)
+		if v != nil || e != nil {
+			cli.Output(templateFor(T_DEPLOYMENT_ID, v), e)
+		} else {
+			if e != nil {
+				cli.Output(templateFor(T_DEPLOYMENT_ID, v), e)
+			}
+		}
+
+	},
+}
+
+var deployCreateCmd = &cobra.Command{
+	Use:   "create",
+	Short: "Creates a new app or group by introspecting the incoming descriptor.  Useful for deployment pipelines",
+	Long: `
+Creates a new app or group by introspecting the incoming descriptor.  Useful for deployment pipelines.
+
+This command has a small penalty of unmarshalling the descriptor twice. One for introspection and
+the other for delegation to the origin (app or group)
+	`,
+
+	Run: func(cmd *cobra.Command, args []string) {
+	},
+}
+
 func init() {
-	deployCmd.AddCommand(deployListCmd, deployDeleteCmd)
+
+	deployCreateCmd.Flags().String(TEMPLATE_CTX_FLAG, "", "Provides data per environment in JSON form to do a first pass parse of descriptor as template")
+	deployCreateCmd.Flags().BoolP(FORCE_FLAG, "f", false, "Force deployment (updates application if it already exists)")
+	deployCreateCmd.Flags().Bool(STOP_DEPLOYS_FLAG, false, "Stop an existing deployment for this app (if exists) and use this revision")
+	deployCreateCmd.Flags().BoolP(IGNORE_MISSING, "i", false, `Ignore missing ${PARAMS} that are declared in app config that could not be resolved
+                        CAUTION: This can be dangerous if some params define versions or other required information.`)
+	deployCreateCmd.Flags().StringP(ENV_FILE_FLAG, "c", "", `Adds a file with a param(s) that can be used for substitution.
+						These take precidence over env vars`)
+	deployCreateCmd.Flags().StringSliceP(PARAMS_FLAG, "p", nil, `Adds a param(s) that can be used for substitution.
+                  eg. -p MYVAR=value would replace ${MYVAR} with "value" in the application file.
+                  These take precidence over env vars`)
+
+	deployDeleteCmd.Flags().BoolP(FORCE_FLAG, "f", false, "If set to true, then the deployment is still canceled but no rollback deployment is created.")
+	deployCmd.AddCommand(deployListCmd, deployDeleteCmd, deleteIfDeployingCmd)
 }

--- a/commands/marathon/marathon_cmds.go
+++ b/commands/marathon/marathon_cmds.go
@@ -16,6 +16,7 @@ const (
 	ENV_FILE_FLAG  string = "env-file"
 	IGNORE_MISSING string = "ignore"
 	INSECURE_FLAG  string = "insecure"
+	ENV_NAME       string = "env_name"
 )
 
 var (
@@ -54,7 +55,7 @@ func associateServiceCommands(parent *cobra.Command) {
 
 func client(c *cobra.Command) marathon.Marathon {
 	if marathonClient == nil {
-		envName := viper.GetString("env_name")
+		envName := viper.GetString(ENV_NAME)
 		insecure := viper.GetBool(INSECURE_FLAG)
 		mc := *configFile.Environments[envName].Marathon
 		opts := &marathon.MarathonOptions{}

--- a/commands/marathon/resources/testcontext.json
+++ b/commands/marathon/resources/testcontext.json
@@ -1,0 +1,25 @@
+{
+  "environments": {
+    "-": {
+      "apps": {
+        "appa": {
+          "mem": 200,
+          "instances": 1,
+          "cpus": 0.1
+        },
+        "appb": {
+          "mem": 850,
+          "instances": 1
+        }
+      }
+    },
+    "prod": {
+      "apps": {
+        "appa": {
+          "mem": 300,
+          "instances": 3
+        }
+      }
+    }
+  }
+}

--- a/commands/marathon/templatectx.go
+++ b/commands/marathon/templatectx.go
@@ -1,0 +1,135 @@
+package marathon
+
+import (
+	"io"
+	"io/ioutil"
+	"os"
+	"reflect"
+	"text/template"
+
+	"github.com/ContainX/depcon/pkg/encoding"
+	"github.com/spf13/viper"
+)
+
+const (
+	DefaultEnv = "-"
+)
+
+// Templated based Functions
+var Funcs = template.FuncMap{
+	"default": func(args ...interface{}) interface{} {
+
+		arg := args[0]
+		if len(args) < 2 {
+			return arg
+		}
+		value := args[1]
+
+		defer recovery()
+
+		v := reflect.ValueOf(value)
+		switch v.Kind() {
+		case reflect.String, reflect.Slice, reflect.Array, reflect.Map:
+			if v.Len() == 0 {
+				return arg
+			}
+		case reflect.Bool:
+			if !v.Bool() {
+				return arg
+			}
+		default:
+			return value
+		}
+
+		return value
+	},
+}
+
+type TemplateContext struct {
+	Environments map[string]*TemplateEnvironment `json:"environments,omitempty"`
+}
+
+type TemplateEnvironment struct {
+	Apps map[string]map[string]interface{} `json:"apps,omitempty"`
+}
+
+func (ctx *TemplateContext) Transform(writer io.Writer, descriptor string) error {
+	var t *template.Template
+
+	if b, err := ioutil.ReadFile(descriptor); err != nil {
+		return err
+	} else {
+		var e error
+		t = template.New("output").Funcs(Funcs)
+		t, e = t.Parse(string(b))
+		if e != nil {
+			return e
+		}
+	}
+	if err := t.Execute(writer, ctx.mergeAppWithDefault(string(viper.GetString(ENV_NAME)))); err != nil {
+		return err
+	}
+	return nil
+}
+
+// Validates the specified app is declared within the current envirnoment. If it is any values missing from
+// specific environment are propagated from the default environment
+func (ctx *TemplateContext) mergeAppWithDefault(env string) map[string]map[string]interface{} {
+	if _, exists := ctx.Environments[DefaultEnv]; !exists {
+		if _, cok := ctx.Environments[env]; !cok {
+			return make(map[string]map[string]interface{})
+		}
+		return ctx.Environments[env].Apps
+	}
+
+	defm := ctx.Environments[DefaultEnv].Apps
+
+	if ctx.Environments[env] == nil {
+		return defm
+	}
+
+	envm := ctx.Environments[env].Apps
+
+	merged := make(map[string]map[string]interface{})
+
+	for app, props := range envm {
+		merged[app] = props
+	}
+
+	for app, props := range defm {
+		if _, exists := merged[app]; !exists {
+			merged[app] = props
+		} else {
+			for k, v := range props {
+				if _, ok := merged[app][k]; !ok {
+					merged[app][k] = v
+				}
+			}
+
+		}
+	}
+	return merged
+}
+
+func recovery() {
+	recover()
+}
+
+func LoadTemplateContext(filename string) (*TemplateContext, error) {
+	ctx, err := os.Open(filename)
+	if err != nil {
+		return nil, err
+	}
+
+	encoder, err := encoding.NewEncoder(encoding.JSON)
+	if err != nil {
+		return nil, err
+	}
+
+	result := &TemplateContext{Environments: make(map[string]*TemplateEnvironment)}
+
+	if err := encoder.UnMarshal(ctx, result); err != nil {
+		return nil, err
+	}
+	return result, nil
+}

--- a/commands/marathon/templatectx_test.go
+++ b/commands/marathon/templatectx_test.go
@@ -1,0 +1,18 @@
+package marathon
+
+import (
+	"github.com/stretchr/testify/assert"
+	"testing"
+)
+
+func TestMergeFunctionality(t *testing.T) {
+	tc, err := LoadTemplateContext("resources/testcontext.json")
+	assert.NoError(t, err)
+
+	m := tc.mergeAppWithDefault("prod")
+
+	assert.Equal(t, float64(0.1), m["appa"]["cpus"])
+	assert.Equal(t, float64(3), m["appa"]["instances"])
+	assert.Equal(t, float64(300), m["appa"]["mem"])
+
+}

--- a/commands/marathon/templates.go
+++ b/commands/marathon/templates.go
@@ -33,7 +33,11 @@ const (
 {{- end}}
 {{ "Environment:" }}
 {{ range $key, $value := .Env }}		{{ $key | pad }} {{ $value }}
-{{end}}`
+{{end}}
+{{ "Labels:" }}
+{{ range $key, $value := .Labels }}		{{ $key | pad }} {{ $value }}
+{{end}}
+`
 
 	T_VERSIONS = `
 {{ "VERSIONS" }}

--- a/compose/compose_wrapper.go
+++ b/compose/compose_wrapper.go
@@ -109,7 +109,7 @@ func (c *ComposeWrapper) createDockerContext() (project.APIProject, error) {
 		if err != nil {
 			return nil, fmt.Errorf("Error opening filename %s, %s", c.context.ComposeFile, err.Error())
 		}
-		parsed, missing := envsubst.SubstFileTokens(file, c.context.ComposeFile, c.context.EnvParams)
+		parsed, missing := envsubst.SubstFileTokens(file, c.context.EnvParams)
 		log.Debug("Map: %v\nParsed: %s\n", c.context.EnvParams, parsed)
 
 		if c.context.ErrorOnMissingParams && missing {

--- a/marathon/application.go
+++ b/marathon/application.go
@@ -126,11 +126,19 @@ func (c *MarathonClient) UpdateApplication(app *Application, wait bool) (*Applic
 }
 
 func (c *MarathonClient) ListApplications() (*Applications, error) {
+	return c.ListApplicationsWithFilters("")
+}
+
+func (c *MarathonClient) ListApplicationsWithFilters(filter string) (*Applications, error) {
 	log.Debug("Enter: ListApplications")
 
 	apps := new(Applications)
 
-	resp := c.http.HttpGet(c.marathonUrl(API_APPS), apps)
+	url := c.marathonUrl(API_APPS)
+	if len(filter) > 0 {
+		url = fmt.Sprintf("%s?%s", url, filter)
+	}
+	resp := c.http.HttpGet(url, apps)
 	if resp.Error != nil {
 		return nil, resp.Error
 	}

--- a/marathon/application_test.go
+++ b/marathon/application_test.go
@@ -19,7 +19,7 @@ func TestCreateApplicationFromFile(t *testing.T) {
 	opts := &CreateOptions{Wait: false, Force: true, ErrorOnMissingParams: true, EnvParams: envParams}
 
 	c := MarathonClient{}
-	app, _, err := c.ParseApplicationFromFile(AppsFolder+"app_params.json", opts)
+	app, err := c.ParseApplicationFromFile(AppsFolder+"app_params.json", opts)
 	if err != nil {
 		log.Panic("Expected success %v", err)
 	}

--- a/marathon/bluegreen/deployment.go
+++ b/marathon/bluegreen/deployment.go
@@ -37,7 +37,7 @@ func (c *BGClient) DeployBlueGreenFromFile(filename string) (*marathon.Applicati
 		ErrorOnMissingParams: c.opts.ErrorOnMissingParams,
 		EnvParams:            c.opts.EnvParams,
 	}
-	app, _, err := c.marathon.ParseApplicationFromFile(filename, parseOpts)
+	app, err := c.marathon.ParseApplicationFromFile(filename, parseOpts)
 	if err != nil {
 		return nil, err
 	}

--- a/marathon/marathon.go
+++ b/marathon/marathon.go
@@ -41,18 +41,32 @@ type CreateOptions struct {
 	// Additional environment params - looks at this map for token substitution which takes
 	// priority over matching environment variables
 	EnvParams map[string]string
+
+	// If an existing deployment for this group/app is in progress then remove it and let this revision
+	// take its place
+	StopDeploy bool
+
+	TemplateMap map[string]string
 }
 
 type Marathon interface {
 
 	/** Application API */
 
-	// Creates a new Application from a file and replaces tokenized variables
+	// Creates a new Application from a file and replaces the tokenized variables
 	// with resolved environment values
 	//
 	// {filename} - the application file of type [ json | yaml ]
 	// {opts}     - create application options
 	CreateApplicationFromFile(filename string, opts *CreateOptions) (*Application, error)
+
+	// Creates a new Application from a file and replaces the tokenized variables
+	// with the resolved environment values
+	//
+	// {filename} - the original filename used to determine the format
+	// {appstr}   - the application in yml or json form
+	// {opts}     - the create application options
+	CreateApplicationFromString(filename string, appstr string, opts *CreateOptions) (*Application, error)
 
 	// Creates a new Application
 	// {app}   - the application structure containing configuration
@@ -63,7 +77,7 @@ type Marathon interface {
 
 	// Responsible for parsing an application [ json | yaml ] and susbstituting variables.
 	// This method is called as part of the CreateApplicationFromFile method.
-	ParseApplicationFromFile(filename string, opts *CreateOptions) (*Application, *CreateOptions, error)
+	ParseApplicationFromFile(filename string, opts *CreateOptions) (*Application, error)
 
 	// Updates an Application
 	// {app} - the application structure containing configuration
@@ -123,7 +137,13 @@ type Marathon interface {
 
 	// Deletes a deployment
 	// {id} - deployment identifier
-	DeleteDeployment(id string) (*DeploymentID, error)
+	// {force} - If set to true, then the deployment is still canceled but no rollback deployment is created.
+	DeleteDeployment(id string, force bool) (*DeploymentID, error)
+
+	// Cancels an active deployment matching the specified application id (conditional match)
+	// {appId} - the application identifier to match the request on
+	// {matchPrefix} - if true only the prefix will be matched, false the whole id must be matched
+	CancelAppDeployment(appId string, matchPrefix bool) (*DeploymentID, error)
 
 	// Waits for a deployment to finish for max timeout duration
 	WaitForDeployment(id string, timeout time.Duration) error
@@ -136,6 +156,14 @@ type Marathon interface {
 	// {filename} - the group file of type [ json | yaml ]
 	// {opts}     - create application options
 	CreateGroupFromFile(filename string, opts *CreateOptions) (*Group, error)
+
+	// Creates a new Group from a string and replaces the tokenized variables
+	// with the resolved environment values
+	//
+	// {filename} - the original filename used to determine the format
+	// {grpstr}   - the group in yml or json form
+	// {opts}     - the create application options
+	CreateGroupFromString(filename string, grpstr string, opts *CreateOptions) (*Group, error)
 
 	// Creates a new Group
 	// {group} - the group structure containing configuration

--- a/marathon/marathon.go
+++ b/marathon/marathon.go
@@ -73,6 +73,9 @@ type Marathon interface {
 	// List all applications on a Marathon cluster
 	ListApplications() (*Applications, error)
 
+	// List all applications on a Marathon cluster with filtering Options
+	ListApplicationsWithFilters(filter string) (*Applications, error)
+
 	// Get an Application by Id
 	// {id} - application identifier
 	GetApplication(id string) (*Application, error)

--- a/pkg/encoding/encoder.go
+++ b/pkg/encoding/encoder.go
@@ -40,13 +40,23 @@ func NewEncoder(encoder EncoderType) (Encoder, error) {
 }
 
 func NewEncoderFromFileExt(filename string) (Encoder, error) {
+
+	if et, err := EncoderTypeFromExt(filename); err != nil {
+		return nil, err
+	} else {
+		return NewEncoder(et)
+	}
+}
+
+func EncoderTypeFromExt(filename string) (EncoderType, error) {
 	switch filepath.Ext(filename) {
 	case ".yml", ".yaml":
-		return NewEncoder(YAML)
+		return YAML, nil
 	case ".json":
-		return NewEncoder(JSON)
+		return JSON, nil
 	}
-	return nil, ErrorInvalidExtension
+	return JSON, ErrorInvalidExtension
+
 }
 
 func ConvertFile(infile, outfile string, dataType interface{}) error {

--- a/pkg/envsubst/envsubst.go
+++ b/pkg/envsubst/envsubst.go
@@ -192,13 +192,13 @@ func Substitute(in io.Reader, preserveUndef bool, resolver func(string) string) 
 	return buf.String()
 }
 
-func SubstFileTokens(in io.Reader, filename string, params map[string]string) (parsed string, missing bool) {
+func SubstFileTokens(in io.Reader, params map[string]string) (parsed string, missing bool) {
 	parsed = Substitute(in, true, func(s string) string {
 		if params != nil && params[s] != "" {
 			return params[s]
 		}
 		if os.Getenv(s) == "" {
-			log.Warning("Cannot find a value for varible ${%s} which was defined in %s", s, filename)
+			log.Warning("Cannot find a value for varible ${%s} in template", s)
 			missing = true
 		}
 		return os.Getenv(s)

--- a/utils/utils.go
+++ b/utils/utils.go
@@ -60,7 +60,7 @@ func ConcatIdentifiers(ids []string) string {
 		if idx > 0 {
 			b.WriteString(" ,")
 		}
-		b.WriteString(TrimRootPath(id))
+		b.WriteString(id)
 	}
 	return b.String()
 }


### PR DESCRIPTION
 - Support new ability to provide a template context and do a first-pass parse of a Group or Application template as a Go Template
- Ability to deploy an App or Group with a new flag called --stop-deploys, which will stop looping deploys for the same app/group being re-deployed
- Ability to force without rollback a deployment via "deploy delete" syntax
- add label,id,cmd based filtering on app list.  support labels in column app get