### PR TITLE
Added new "deploy create" command which will auto-detect if the YML o…

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-VERSION = 0.8.8
+VERSION = 0.8.9
 
 GO_FMT = gofmt -s -w -l .
 GO_XC = goxc -os="linux darwin windows" -tasks-="rmbin"

--- a/marathon/struct.go
+++ b/marathon/struct.go
@@ -244,6 +244,16 @@ type Step struct {
 	App    string `json:"app"`
 }
 
+type AppOrGroup struct {
+	ID     string         `json:"id"`
+	Apps   []*Application `json:"apps,omitempty"`
+	Groups []*Group       `json:"groups,omitempty"`
+}
+
+func (ag *AppOrGroup) IsApplication() bool {
+	return ag.Apps == nil && ag.Groups == nil
+}
+
 type Group struct {
 	GroupID      string         `json:"id"`
 	Version      string         `json:"version,omitempty"`


### PR DESCRIPTION
Added new "deploy create" command which will auto-detect if the YML or JSON descriptor is a Marathon App or Group.  Offer the same flags as Group/App creates but the flexibility let app teams to create descriptors based on their needs.