### PR TITLE
Support for http authorisation token 

### DIFF
--- a/cliconfig/config.go
+++ b/cliconfig/config.go
@@ -60,6 +60,7 @@ type ConfigEnvironment struct {
 type ServiceConfig struct {
 	Username string            `json:"username,omitempty"`
 	Password string            `json:"password,omitempty"`
+	Token    string            `json:"token"`
 	HostUrl  string            `json:"serveraddress,omitempty"`
 	Features map[string]string `json:"features,omitempty"`
 	Name     string            `json:"-"`
@@ -134,12 +135,13 @@ func (configFile *ConfigFile) AddEnvironment() {
 	configFile.Save()
 }
 
-func (configFile *ConfigFile) AddMarathonEnvironment(name, host, user, pass string) {
+func (configFile *ConfigFile) AddMarathonEnvironment(name, host, user, pass, token string) {
 	service := &ServiceConfig{}
 	service.Name = name
 	service.HostUrl = host
 	service.Username = user
 	service.Password = pass
+	service.Token = token
 
 	configEnv := &ConfigEnvironment{
 		Marathon: service,

--- a/cliconfig/create_config.go
+++ b/cliconfig/create_config.go
@@ -16,7 +16,7 @@ we are only dealing with a single service and know what it is.
 Root single environment`
 )
 
-func CreateMemoryMarathonConfig(host, user, password string) *ConfigFile {
+func CreateMemoryMarathonConfig(host, user, password, token string) *ConfigFile {
 	configFile, _ := Load("")
 	configFile.RootService = true
 	configFile.Format = "column"
@@ -25,6 +25,7 @@ func CreateMemoryMarathonConfig(host, user, password string) *ConfigFile {
 		HostUrl:  host,
 		Username: user,
 		Password: password,
+		Token: token,
 	}
 	configEnv := &ConfigEnvironment{
 		Marathon: serviceEnv,

--- a/cliconfig/create_environment.go
+++ b/cliconfig/create_environment.go
@@ -50,6 +50,16 @@ func getPasswordWithVerify() string {
 	return pass1
 }
 
+func getTokenWithVerify() string {
+	token := getPassword("Token: ")
+	token2 := getPassword("Verify Token: ")
+	if token != token2 {
+		fmt.Println("Token and Verify Token don't match\n")
+		return getTokenWithVerify()
+	}
+	return token
+}
+
 // Asks the user for the remote URI of the Marathon service
 func getMarathonURL(count int) string {
 	if count > 5 {
@@ -86,6 +96,11 @@ func createEnvironment() *ServiceConfig {
 		service.Username = getAlpaNumDash("Username")
 		service.Password = getPasswordWithVerify()
 	}
+
+	if getBoolAnswer("Token Required", false) {
+		service.Token = getTokenWithVerify()
+	}
+
 	fmt.Println("")
 	return &service
 }

--- a/commands/depcon.go
+++ b/commands/depcon.go
@@ -20,6 +20,7 @@ const (
 	EnvMarathonHost = "MARATHON_HOST"
 	EnvMarathonUser = "MARATHON_USER"
 	EnvMarathonPass = "MARATHON_PASS"
+	EnvMarathonToken = "MARATHON_TOKEN"
 	FlagEnv         = "env"
 	ViperEnv        = "env_name"
 	EnvHelp         = `Specifies the Environment name to use (eg. test | prod | etc). This can be omitted if only a single environment has been defined`
@@ -93,7 +94,7 @@ func Execute() {
 }
 
 func marathonConfigFromEnv() *cliconfig.ConfigFile {
-	return cliconfig.CreateMemoryMarathonConfig(os.Getenv(EnvMarathonHost), os.Getenv(EnvMarathonUser), os.Getenv(EnvMarathonPass))
+	return cliconfig.CreateMemoryMarathonConfig(os.Getenv(EnvMarathonHost), os.Getenv(EnvMarathonUser), os.Getenv(EnvMarathonPass), os.Getenv(EnvMarathonToken))
 }
 
 func determineEnvironment() string {

--- a/commands/marathon/app_cmds.go
+++ b/commands/marathon/app_cmds.go
@@ -233,7 +233,7 @@ func updateAppCPU(cmd *cobra.Command, args []string) {
 		os.Exit(1)
 	}
 	update := marathon.NewApplication(args[0]).CPU(cpu)
-	v, e := client(cmd).UpdateApplication(update, wait)
+	v, e := client(cmd).UpdateApplication(update, wait, false)
 	cli.Output(templateFor(T_APPLICATION, v), e)
 }
 
@@ -250,7 +250,7 @@ func updateAppMemory(cmd *cobra.Command, args []string) {
 		os.Exit(1)
 	}
 	update := marathon.NewApplication(args[0]).Memory(mem)
-	v, e := client(cmd).UpdateApplication(update, wait)
+	v, e := client(cmd).UpdateApplication(update, wait, false)
 	cli.Output(templateFor(T_APPLICATION, v), e)
 }
 
@@ -271,7 +271,7 @@ func rollbackAppVersion(cmd *cobra.Command, args []string) {
 		}
 	}
 	update := marathon.NewApplication(args[0]).RollbackVersion(version)
-	v, e := client(cmd).UpdateApplication(update, wait)
+	v, e := client(cmd).UpdateApplication(update, wait, false)
 	cli.Output(templateFor(T_APPLICATION, v), e)
 }
 

--- a/commands/marathon/marathon_cmds.go
+++ b/commands/marathon/marathon_cmds.go
@@ -69,7 +69,7 @@ func client(c *cobra.Command) marathon.Marathon {
 		}
 		opts.TLSAllowInsecure = insecure
 
-		marathonClient = marathon.NewMarathonClientWithOpts(mc.HostUrl, mc.Username, mc.Password, opts)
+		marathonClient = marathon.NewMarathonClientWithOpts(mc.HostUrl, mc.Username, mc.Password, mc.Token, opts)
 
 	}
 	return marathonClient

--- a/marathon/application_test.go
+++ b/marathon/application_test.go
@@ -36,7 +36,7 @@ func TestListApplications(t *testing.T) {
 	s := mockrest.StartNewWithFile(AppsFolder + "list_apps_response.json")
 	defer s.Stop()
 
-	c := NewMarathonClient(s.URL, "", "")
+	c := NewMarathonClient(s.URL, "", "", "")
 	apps, err := c.ListApplications()
 
 	assert.Nil(t, err, "Error response was not expected")
@@ -47,7 +47,7 @@ func TestGetApplication(t *testing.T) {
 	s := mockrest.StartNewWithFile(AppsFolder + "get_app_response.json")
 	defer s.Stop()
 
-	c := NewMarathonClient(s.URL, "", "")
+	c := NewMarathonClient(s.URL, "", "", "")
 	app, err := c.GetApplication("storage/redis-x")
 
 	assert.Nil(t, err, "Error response was not expected")
@@ -61,7 +61,7 @@ func TestHasApplication(t *testing.T) {
 	s := mockrest.StartNewWithFile(AppsFolder + "get_app_response.json")
 	defer s.Stop()
 
-	c := NewMarathonClient(s.URL, "", "")
+	c := NewMarathonClient(s.URL, "", "", "")
 	ok, err := c.HasApplication("/storage/redis-x")
 
 	assert.Nil(t, err, "Error response was not expected")
@@ -72,7 +72,7 @@ func TestHasApplicationInvalid(t *testing.T) {
 	s := mockrest.StartNewWithStatusCode(404)
 	defer s.Stop()
 
-	c := NewMarathonClient(s.URL, "", "")
+	c := NewMarathonClient(s.URL, "", "", "")
 	ok, _ := c.HasApplication("/storage/redis-invalid")
 
 	assert.Equal(t, false, ok)
@@ -82,7 +82,7 @@ func TestDestroyApplication(t *testing.T) {
 	s := mockrest.StartNewWithFile(CommonFolder + "deployid_response.json")
 	defer s.Stop()
 
-	c := NewMarathonClient(s.URL, "", "")
+	c := NewMarathonClient(s.URL, "", "", "")
 	depId, err := c.DestroyApplication("/someapp")
 	assert.Nil(t, err, "Error response was not expected")
 	assert.Equal(t, "5ed4c0c5-9ff8-4a6f-a0cd-f57f59a34b43", depId.DeploymentID)
@@ -92,7 +92,7 @@ func TestRestartApplication(t *testing.T) {
 	s := mockrest.StartNewWithFile(CommonFolder + "deployid_response.json")
 	defer s.Stop()
 
-	c := NewMarathonClient(s.URL, "", "")
+	c := NewMarathonClient(s.URL, "", "", "")
 	depId, err := c.DestroyApplication("/someapp")
 	assert.Nil(t, err, "Error response was not expected")
 	assert.Equal(t, "5ed4c0c5-9ff8-4a6f-a0cd-f57f59a34b43", depId.DeploymentID)
@@ -102,7 +102,7 @@ func TestScaleApplication(t *testing.T) {
 	s := mockrest.StartNewWithFile(CommonFolder + "deployid_response.json")
 	defer s.Stop()
 
-	c := NewMarathonClient(s.URL, "", "")
+	c := NewMarathonClient(s.URL, "", "", "")
 	depId, err := c.ScaleApplication("/someapp", 5)
 	assert.Nil(t, err, "Error response was not expected")
 	assert.Equal(t, "5ed4c0c5-9ff8-4a6f-a0cd-f57f59a34b43", depId.DeploymentID)
@@ -112,7 +112,7 @@ func TestCreateApplicationInvalidAppId(t *testing.T) {
 	s := mockrest.StartNewWithStatusCode(422)
 	defer s.Stop()
 
-	c := NewMarathonClient(s.URL, "", "")
+	c := NewMarathonClient(s.URL, "", "", "")
 	_, err := c.CreateApplication(NewApplication("/someapp"), false, false)
 
 	assert.NotNil(t, err, "Expecting Error")

--- a/marathon/group.go
+++ b/marathon/group.go
@@ -131,7 +131,7 @@ func (c *MarathonClient) UpdateGroup(group *Group, wait bool) (*Group, error) {
 	if resp.Error != nil {
 		if resp.Error == httpclient.ErrorMessage {
 			if resp.Status == 422 {
-				return nil, ErrorGropAppExists
+				return nil, ErrorGroupAppExists
 			}
 		}
 		return nil, resp.Error

--- a/marathon/group_test.go
+++ b/marathon/group_test.go
@@ -14,7 +14,7 @@ func TestListGroups(t *testing.T) {
 	s := mockrest.StartNewWithFile(GroupsFolder + "list_groups_response.json")
 	defer s.Stop()
 
-	c := NewMarathonClient(s.URL, "", "")
+	c := NewMarathonClient(s.URL, "", "", "")
 	groups, err := c.ListGroups()
 
 	assert.Nil(t, err, "Error response was not expected")
@@ -26,7 +26,7 @@ func TestGetGroup(t *testing.T) {
 	s := mockrest.StartNewWithFile(GroupsFolder + "get_group_response.json")
 	defer s.Stop()
 
-	c := NewMarathonClient(s.URL, "", "")
+	c := NewMarathonClient(s.URL, "", "", "")
 	group, err := c.GetGroup("/sites")
 
 	assert.Nil(t, err, "Error response was not expected")
@@ -37,7 +37,7 @@ func TestDestroyGroup(t *testing.T) {
 	s := mockrest.StartNewWithFile(CommonFolder + "deployid_response.json")
 	defer s.Stop()
 
-	c := NewMarathonClient(s.URL, "", "")
+	c := NewMarathonClient(s.URL, "", "", "")
 	depId, err := c.DestroyGroup("/sites")
 	assert.Nil(t, err, "Error response was not expected")
 	assert.Equal(t, "5ed4c0c5-9ff8-4a6f-a0cd-f57f59a34b43", depId.DeploymentID)

--- a/marathon/marathon.go
+++ b/marathon/marathon.go
@@ -87,7 +87,8 @@ type Marathon interface {
 	// Updates an Application
 	// {app} - the application structure containing configuration
 	// {wait} - if true will attempt to wait until the application updated is running
-	UpdateApplication(app *Application, wait bool) (*Application, error)
+	// {force} - if true and a application already exists an update will be performed.
+	UpdateApplication(app *Application, wait, force bool) (*Application, error)
 
 	// List all applications on a Marathon cluster
 	ListApplications() (*Applications, error)

--- a/marathon/marathon.go
+++ b/marathon/marathon.go
@@ -265,24 +265,25 @@ type MarathonOptions struct {
 	TLSAllowInsecure bool
 }
 
-func NewMarathonClient(host, username, password string) Marathon {
-	return createMarathonClient(username, password, nil, host)
+func NewMarathonClient(host, username, password, token string) Marathon {
+	return createMarathonClient(username, password, token, nil, host)
 }
 
-func NewMarathonClientWithOpts(host, username, password string, opts *MarathonOptions) Marathon {
-	return createMarathonClient(username, password, opts, host)
+func NewMarathonClientWithOpts(host, username, password, token string, opts *MarathonOptions) Marathon {
+	return createMarathonClient(username, password, token, opts, host)
 }
 
 // NewHAMarathonClientWithOpts creates a new Marathon client setup for HA mode.  All the specified
 // hosts will be healthchecked and healthy ones will be returned when this library requests a host
-func NewHAMarathonClientWithOpts(username, password string, opts *MarathonOptions, hosts ...string) Marathon {
-	return &MarathonHAClient{createMarathonClient(username, password, opts, hosts...)}
+func NewHAMarathonClientWithOpts(username, password, token string, opts *MarathonOptions, hosts ...string) Marathon {
+	return &MarathonHAClient{createMarathonClient(username, password, token, opts, hosts...)}
 }
 
-func createMarathonClient(username, password string, opts *MarathonOptions, hosts ...string) *MarathonClient {
+func createMarathonClient(username, password, token string, opts *MarathonOptions, hosts ...string) *MarathonClient {
 	httpConfig := httpclient.NewDefaultConfig()
 	httpConfig.HttpUser = username
 	httpConfig.HttpPass = password
+	httpConfig.HttpToken = token
 
 	if opts != nil && opts.TLSAllowInsecure {
 		httpConfig.TLSInsecureSkipVerify = opts.TLSAllowInsecure

--- a/marathon/marathon.go
+++ b/marathon/marathon.go
@@ -284,6 +284,10 @@ func createMarathonClient(username, password string, opts *MarathonOptions, host
 	httpConfig.HttpUser = username
 	httpConfig.HttpPass = password
 
+	if opts != nil && opts.TLSAllowInsecure {
+		httpConfig.TLSInsecureSkipVerify = opts.TLSAllowInsecure
+	}
+
 	httpClient := httpclient.NewHttpClient(*httpConfig)
 
 	c := new(MarathonClient)

--- a/pkg/httpclient/client.go
+++ b/pkg/httpclient/client.go
@@ -4,6 +4,7 @@ package httpclient
 import (
 	"crypto/tls"
 	"errors"
+	"fmt"
 	"github.com/ContainX/depcon/pkg/encoding"
 	"github.com/ContainX/depcon/pkg/logger"
 	"io"
@@ -42,6 +43,8 @@ type HttpClientConfig struct {
 	HttpUser string
 	// Http Basic Auth Password
 	HttpPass string
+	// Http Authorization Token
+	HttpToken string
 	// Request timeout
 	RequestTimeout int
 	// TLS Insecure Skip Verify
@@ -217,6 +220,10 @@ func AddDefaultHeaders(req *http.Request) {
 }
 
 func AddAuthentication(c HttpClientConfig, req *http.Request) {
+	if c.HttpToken != "" {
+		req.Header.Set("Authorization", fmt.Sprintf("token=%v", c.HttpToken))
+		return
+	}
 	if c.HttpUser != "" {
 		req.SetBasicAuth(c.HttpUser, c.HttpPass)
 	}

--- a/pkg/httpclient/client.go
+++ b/pkg/httpclient/client.go
@@ -145,7 +145,7 @@ func (h *HttpClient) CreateHttpRequest(method, urlStr string, body io.Reader) (*
 
 func (h *HttpClient) invoke(r *Request) *Response {
 
-	log.Debug("%s - %s, Body:\n%s", r.method.String(), r.url, r.data)
+	log.Debugf("%s - %s, Body:\n%s", r.method.String(), r.url, r.data)
 
 	request, err := h.CreateHttpRequest(r.method.String(), r.url, strings.NewReader(r.data))
 
@@ -172,7 +172,7 @@ func (h *HttpClient) invoke(r *Request) *Response {
 		content = string(rc)
 	}
 
-	log.Debug("Status: %v, RAW: %s", status, content)
+	log.Debugf("Status: %v, RAW: %s", status, content)
 
 	if status >= 200 && status < 300 {
 		if r.result != nil {


### PR DESCRIPTION
This pull request tackles two issues:

- #25 - making sure the **insecure** flag is applied to the http request
- #43 - adds the option to use the authorisation token besides the existent basic authentication. However when token authorisation is used basic authentication is suppressed.