### PR TITLE
Add command health check

### DIFF
--- a/marathon/struct.go
+++ b/marathon/struct.go
@@ -148,13 +148,18 @@ type UpgradeStrategy struct {
 }
 
 type HealthCheck struct {
-	Protocol               string `json:"protocol,omitempty"`
-	Path                   string `json:"path,omitempty"`
-	GracePeriodSeconds     int    `json:"gracePeriodSeconds,omitempty"`
-	IntervalSeconds        int    `json:"intervalSeconds,omitempty"`
-	PortIndex              int    `json:"portIndex,omitempty"`
-	MaxConsecutiveFailures int    `json:"maxConsecutiveFailures,omitempty"`
-	TimeoutSeconds         int    `json:"timeoutSeconds,omitempty"`
+	Protocol               string              `json:"protocol,omitempty"`
+	Command                *HealthCheckCommand `json:"command,omitempty"`
+	Path                   string              `json:"path,omitempty"`
+	GracePeriodSeconds     int                 `json:"gracePeriodSeconds,omitempty"`
+	IntervalSeconds        int                 `json:"intervalSeconds,omitempty"`
+	PortIndex              int                 `json:"portIndex,omitempty"`
+	MaxConsecutiveFailures int                 `json:"maxConsecutiveFailures,omitempty"`
+	TimeoutSeconds         int                 `json:"timeoutSeconds,omitempty"`
+}
+
+type HealthCheckCommand struct {
+	Value string `json:"value,omitempty"`
 }
 
 type TaskIPAddress struct {


### PR DESCRIPTION
This change will allow users to specify a COMMAND health check, as outline in the marathon docs. Here is the example they give

```
{
  "protocol": "COMMAND",
  "command": { "value": "curl -f -X GET http://$HOST:$PORT0/health" },
  "gracePeriodSeconds": 300,
  "intervalSeconds": 60,
  "timeoutSeconds": 20,
  "maxConsecutiveFailures": 3
}
```